### PR TITLE
Add embed command

### DIFF
--- a/cmds/cmd_starboard.py
+++ b/cmds/cmd_starboard.py
@@ -75,7 +75,7 @@ category_info = {'name': 'starboard', 'pretty_name': 'Starboard', 'description':
 commands = {
     'starboard-channel': {
         'pretty_name': 'starboard-channel <channel>',
-        'description': 'Change Starboard',
+        'description': 'Change starboard channel',
         'permission': 'administrator',
         'cache': 'keep',
         'execute': starboard_channel_change

--- a/cmds/cmd_utils.py
+++ b/cmds/cmd_utils.py
@@ -40,6 +40,13 @@ async def parse_userid(message, args):
     return user_object
 
 
+def list_default(lst, index, default):
+    try:
+        return lst[index]
+    except IndexError:
+        return default
+
+
 async def ping_function(message, args, client, **kwargs):
     stats = kwargs["stats"]
     ping_embed = discord.Embed(title="Pong!", description="Connection between Sonnet and Discord is OK", color=0x00ff6e)
@@ -101,6 +108,24 @@ async def avatar_function(message, args, client, **kwargs):
     embed.set_image(url=user_object.avatar_url)
     embed.timestamp = datetime.utcnow()
     await message.channel.send(embed=embed)
+
+
+async def embed(message, args, client, **kwargs):
+    desc = " ".join(args)
+
+    if desc == "":
+        await message.channel.send("Please provide a message to send")
+        return
+
+    desc = desc.replace('\\n', '\n')
+
+    if len(desc) > 2048:
+        message = message[:2047]
+
+    user_embed = discord.Embed(description=desc)\
+        .set_author(name=f"From {message.author}", icon_url=message.author.avatar_url)
+
+    await message.channel.send(embed=user_embed)
 
 
 async def help_function(message, args, client, **kwargs):
@@ -197,6 +222,13 @@ commands = {
         'cache': 'keep',
         'execute': avatar_function
         },
+    'embed': {
+        'pretty_name': 'embed [text]',
+        'description': 'Creates an embed (requires mod)',
+        'permission': 'moderator',
+        'cache': 'regenerate',  # Make sure embed is credited to user
+        'execute': embed
+    },
     'serverinfo': {
         'pretty_name': 'serverinfo',
         'description': 'Get info on this guild',


### PR DESCRIPTION
Adds an `embed` command with the format `=embed <message>` to the `utilities` module. The embed is credited to the user in the header, and every argument fed in is combined into one message.

It's tested and working in the dev environment I setup.

It looks something like this:
<img width="216" alt="Screen Shot 2021-01-20 at 8 41 46 PM" src="https://user-images.githubusercontent.com/62847558/105268284-ebbd3b00-5b5f-11eb-981d-192a6a439569.png">

Feedback is much appreciated!

_I also slightly clarified the Starboard channel command, probably should have made that it's own PR_