### PR TITLE
Strip inline code formatted regex

### DIFF
--- a/cmds/cmd_automod.py
+++ b/cmds/cmd_automod.py
@@ -154,7 +154,7 @@ async def remove_regex_type(message: discord.Message, args: List[str], db_entry:
             raise blacklist_input_error("No RegEx")
 
         # Check if in list
-        remove_data = "__REGEXP " + " ".join(args)
+        remove_data = "__REGEXP " + " ".join(args).strip("`")
         if remove_data in curlist["blacklist"]:
             del curlist["blacklist"][curlist["blacklist"].index(remove_data)]
         else:


### PR DESCRIPTION
remove the \` from around the input regex when removing it, since using codeblocks is is the only known way to disable discord formatting this allows the user to pass on raw message content allowing for any data to be removed
not having this makes it so if there is some data discord *insists* on processing - like emoji - but the regex content expects an exact message that is literally impossible to be sent through discord, it can still be removed